### PR TITLE
Wrote a mock-appdir tool that uses mock and rpm to run on rpm-based systems

### DIFF
--- a/mock-appdir/README.md
+++ b/mock-appdir/README.md
@@ -1,0 +1,31 @@
+mock-appdir
+-------------
+
+```mock-appdir``` is a modification of ```apt-appdir``` for RHEL/Fedora-like
+systems. It uses [Mock](https://fedoraproject.org/wiki/Mock), a Fedora package
+building tool, to run inside a chroot.
+
+It does exactly the same thing as ```apt-appdir```, you run it as follows:
+
+```
+mock-appdir/mock-appdir firefox
+```
+
+The Mock chroot is first populated with the Fedora @buildsys-build and @base-x
+groups, along with systemd, so that these do not get included as dependencies.
+
+Then (for example) the Firefox package is installed, along with all of its
+dependencies, and these are extracted using ```rpm2cpio``` and turned into an
+AppDir.
+
+The default chroot is currently **fedora-20-x86_64**. You can change what the
+target is by setting the variable MOCK_TARGET before running, for example:
+
+```
+MOCK_TARGET=fedora-21-x86_64 mock-appdir/mock-appdir firefox
+```
+
+Note that $MOCK_TARGET is just the name of a mock config file in 
+```/etc/mock```.
+
+Ben Rosser <rosser.bjr@gmail.com>

--- a/mock-appdir/mock-appdir
+++ b/mock-appdir/mock-appdir
@@ -33,7 +33,6 @@
 # This should be overridable somehow.
 # F20 is old, no longer supported, but was for 1 year.
 # So this is probably a sane default.
-# (CentOS 7 would be better).
 if [ -z "${MOCK_TARGET}" ]
 then
 	MOCK_TARGET="fedora-20-x86_64"

--- a/mock-appdir/mock-appdir
+++ b/mock-appdir/mock-appdir
@@ -2,7 +2,7 @@
 
 # A version of "apt-appdir" that uses RPM, yum, and mock.
 # Intended to be ran on a Fedora system, or recent CentOS/RHEL.
-# Does not work with dnf yet! Should be an easy fix though.
+# Defaults to Fedora 20 chroot at the moment.
 
 # /**************************************************************************
 # 
@@ -51,9 +51,9 @@ rm -rf  "${APPDIR}"
 # Use mock to download package + all basic dependencies.
 echo "Downloading packages into mock chroot for " ${MOCK_TARGET}
 mock -r ${MOCK_TARGET} --scrub=all
-mock -r ${MOCK_TARGET} --yum-cmd install @buildsys-build
+mock -r ${MOCK_TARGET} --install @base-x --install kmod --install systemd
 mock -r ${MOCK_TARGET} --scrub=cache
-mock -r ${MOCK_TARGET} --yum-cmd install ${APP}
+mock -r ${MOCK_TARGET} --install ${APP}
 
 mkdir "${APPDIR}"
 cd "${APPDIR}"
@@ -62,7 +62,7 @@ cp -v /var/cache/mock/${MOCK_TARGET}/yum_cache/*/packages/*.rpm ./
 # Use rpm2cpio (...) to unbundle the rpms and then remove them.
 for f in *
 do
-	rpm2cpio $f |cpio -idm
+	rpm2cpio $f | cpio -idm
 done
 rm -v *.rpm
 

--- a/mock-appdir/mock-appdir
+++ b/mock-appdir/mock-appdir
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+# A version of "apt-appdir" that uses RPM, yum, and mock.
+# Intended to be ran on a Fedora system, or recent CentOS/RHEL.
+# Does not work with dnf yet! Should be an easy fix though.
+
+# /**************************************************************************
+# 
+# Copyright (c) 2015 Ben Rosser
+# 
+# All Rights Reserved.
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+# 
+# **************************************************************************/
+
+# This should be overridable somehow.
+# F20 is old, no longer supported, but was for 1 year.
+# So this is probably a sane default.
+# (CentOS 7 would be better).
+if [ -z "${MOCK_TARGET}" ]
+then
+	MOCK_TARGET="fedora-20-x86_64"
+fi
+
+DIRNAME=$(dirname $(readlink -f "${0}"))
+
+APP="${1}"
+APPDIR="./${APP}.AppDir"
+
+set -e
+
+rm -rf  "${APPDIR}"
+
+# Use mock to download package + all basic dependencies.
+echo "Downloading packages into mock chroot for " ${MOCK_TARGET}
+mock -r ${MOCK_TARGET} --scrub=all
+mock -r ${MOCK_TARGET} --yum-cmd install @buildsys-build
+mock -r ${MOCK_TARGET} --scrub=cache
+mock -r ${MOCK_TARGET} --yum-cmd install ${APP}
+
+mkdir "${APPDIR}"
+cd "${APPDIR}"
+cp -v /var/cache/mock/${MOCK_TARGET}/yum_cache/*/packages/*.rpm ./
+
+# Use rpm2cpio (...) to unbundle the rpms and then remove them.
+for f in *
+do
+	rpm2cpio $f |cpio -idm
+done
+rm -v *.rpm
+
+# Now do these other steps.
+find . -type f -exec sed -i -e 's|/usr|././|g' {} \;
+find . -type f -exec sed -i -e 's|././/bin/env|/usr/bin/env|g' {} \;
+find . -type f -exec sed -i -e 's|././/bin/python|/usr/bin/python|g' {} \;
+### TODO: need proper IntelliPatch here ###
+
+cp "${DIRNAME}/../AppRun" .
+
+find ./usr/share/py* > /dev/null 2>&1 && echo "Python code has been detected." && \
+echo "Probably you want to insert portability.py into the Python code to" && \
+echo "solve import errors."
+
+# Copy all desktop files to the topmost AppDir level
+# if it's more than one, then the user needs to delete all but one
+# or the result will be undefined
+find . -iname *.desktop -exec cp {} . \;
+
+# This, together with the environment variable set by AppRun, allows Vala apps to run
+if [ -d ./usr/share/glib-2.0/schemas ]
+then
+	glib-compile-schemas ./usr/share/glib-2.0/schemas/
+else
+	echo "No ./usr/share/glib-2.0/schemas/"
+fi
+
+cd -
+
+echo ""
+echo "./${APP}.AppDir created. Now run:"
+echo "./AppImageAssistant ./${APP}.AppDir ./${APP}"
+echo ""

--- a/mock-appdir/portability.py
+++ b/mock-appdir/portability.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python2
+
+import os, sys, fnmatch
+
+AppDir = os.path.realpath(os.path.dirname(__file__))
+
+modules = []
+
+for root, dirs, files in os.walk(AppDir):
+    for fname in files:
+        fpath = os.path.join(root,fname)
+        if fnmatch.fnmatch(fpath, '*__init__.py'):
+            modules.append(os.path.dirname(os.path.dirname(fpath)))
+        if fnmatch.fnmatch(fpath, '*/_*.so'):
+            modules.append(os.path.dirname(fpath))
+        if fnmatch.fnmatch(fpath, '*python*.so'):
+            modules.append(os.path.dirname(fpath))
+        if fnmatch.fnmatch(fpath, '*.py'):
+            modules.append(os.path.dirname(fpath))
+
+modules = set(modules)
+
+for module in modules:
+    sys.path.append(module)
+
+usage = """
+E.g., if the main executable is in $APPDIR/usr/bin, then add to the head of it:
+
+import os,sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__)))))
+import portability
+"""
+
+if __name__=="__main__":
+    print ""
+    print("Put this file into the root of an AppDir, then import it to make all Python modules in the AppDir visible to the app")
+    print usage


### PR DESCRIPTION
I've been working on a project where we've wanted to build software and ship it out of an OpenAFS cell, and while looking into portable versions of Linux software, I discovered AppImages. I thought they were really cool, although (as a Fedora user) I was a little disappointed that a tool to make app directories only existed for Debian systems (```apt-appdir```).

I *also* thought that [Mock](https://fedoraproject.org/wiki/Mock) (a Fedora chroot-powered package builder) would be an ideal way to build AppDirs and ensure most (if not all) dependencies got included. One thing led to another, and I found myself writing a tool...

Because mock instantiates an empty chroot, I first install the X stack and systemd, which also installs the ```@buildsys-build``` group (roughly the Fedora equivalent to debian build-essential). So none of these things get bundled. But any other dependency will.

Then the RPMs that got pulled down for the requested app get copied, extracted by rpm2cpio, and the app directory gets created.

The default chroot is Fedora 20 (64-bit), because while that was recently EOL'd, it is a little old but not terribly out of date yet and also had the longest lifespan of a Fedora release for quite some time now (an entire year). But this is easily changeable.

I have tested this on a Fedora 21 desktop and it seems to work just fine. I was also able to run an output Firefox AppImage on a Debian box.