### PR TITLE
Allow AppImageAssistant to receive parameters with spaces

### DIFF
--- a/AppImageAssistant.AppDir/AppRun
+++ b/AppImageAssistant.AppDir/AppRun
@@ -1,3 +1,3 @@
 #!/bin/bash
 HERE="$(dirname "$(readlink -f "${0}")")"
-PYTHONPATH="${HERE}"/usr/share/pyshared:"$PYTHONPATH" LD_LIBRARY_PATH="${HERE}/usr/lib/:${LD_LIBRARY_PATH}" PATH="${HERE}/:${PATH}" exec "${HERE}"/AppImageAssistant $@
+PYTHONPATH="${HERE}"/usr/share/pyshared:"$PYTHONPATH" LD_LIBRARY_PATH="${HERE}/usr/lib/:${LD_LIBRARY_PATH}" PATH="${HERE}/:${PATH}" exec "${HERE}"/AppImageAssistant "$@"


### PR DESCRIPTION
(from experimental branch)

Needed when the path to the AppDir you want to pack has spaces in it