### PR TITLE
allow create pre-built wheezy arm docker image w/ dependencies

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ fi
 
 if [ -e /usr/bin/apt-get ] ; then
   $SUDO apt-get update
-  $SUDO apt-get -y install libfuse-dev libglib2.0-dev cmake git libc6-dev binutils fuse
+  $SUDO apt-get -y install libfuse-dev libglib2.0-dev cmake git libc6-dev binutils fuse python
 
 fi
 
@@ -52,6 +52,11 @@ if [ -e /usr/bin/pacman ] ; then
       echo "$i is already installed."
     fi
   done
+fi
+
+if [ "$1" == "--fetch-dependencies-only" ] ; then
+  echo "Fetched dependencies.  Exiting now."
+  exit 0
 fi
 
 cd "${HERE}"


### PR DESCRIPTION
added wheezy armel & armhf binaries, downloaded from https://packages.debian.org/wheezy/{armhf,armel}/{unionfs-fuse,ruby-vte,libvte9,libglade2-0}/download (note: wheezy is oldest debian that has these as binary)

if pass --fetch-dependencies-only to build.sh then quit build prematurely before actually compile

added python as apt-get dependency, which is needed if build on a fresh minimal debian wheezy