### PR TITLE
Fixing desktop integration issue with spaces in filenames

### DIFF
--- a/desktopintegration
+++ b/desktopintegration
@@ -180,7 +180,7 @@ fi
 
 # Construct path to the icon according to
 # http://specifications.freedesktop.org/thumbnail-spec/thumbnail-spec-latest.html
-ABS_APPIMAGE=$(readlink -e $APPIMAGE)
+ABS_APPIMAGE=$(readlink -e "$APPIMAGE")
 ICONURL="file://$ABS_APPIMAGE"
 MD5=$(echo -n $ICONURL | md5sum | cut -c -32)
 ICONFILE="$HOME/.cache/thumbnails/normal/$MD5.png"


### PR DESCRIPTION
Closes #164

This PR fixes the issue where desktop integration wouldn't work if there was a space in the filename.