### PR TITLE
Removes specific .zs-old .asc when run appimageupdate

### DIFF
--- a/AppImageUpdate.AppDir/usr/bin/appimageupdate
+++ b/AppImageUpdate.AppDir/usr/bin/appimageupdate
@@ -187,6 +187,6 @@ else
   exit 1
 fi
 
-rm *.zs-old 2>/dev/null || true
+rm "${ISO}.zs-old" "${ISO}.asc" 2>/dev/null || true
 
 echo "Successfully updated to version ${VERSION}"


### PR DESCRIPTION
Removes the `.zs-old` (generated by `zsync_curl`) and `.asc` (downloaded by `gpg_check`) relatives to the AppImage that has been requested to update through `appimageupdate`.