### PR TITLE
Fix error if space in the desktop file

### DIFF
--- a/desktopintegration
+++ b/desktopintegration
@@ -166,7 +166,7 @@ check_dep xdg-desktop-menu
 
 DESKTOPFILE=$(find "$APPDIR" -maxdepth 1 -name "*.desktop" | head -n 1)
 echo "$DESKTOPFILE"
-DESKTOPFILE_NAME=$(basename $DESKTOPFILE)
+DESKTOPFILE_NAME=$(basename "${DESKTOP_FILE}")
 
 if [ ! -f "$DESKTOPFILE" ] ; then
   echo "Desktop file is missing. Please run ${THIS} from within an AppImage."


### PR DESCRIPTION
electron-builder in any case uses own version of desktop integration file, but I want to fix original :)

Relates to #167