### PR TITLE
Expose the original $CWD as an environment variable

### DIFF
--- a/runtime.c
+++ b/runtime.c
@@ -359,6 +359,13 @@ main (int argc, char *argv[])
     /* Setting some environment variables that the app "inside" might use */
     setenv( "APPIMAGE", fullpath, 1 );
     setenv( "APPDIR", mount_dir, 1 );
+
+    /* Original working directory */
+    char cwd[1024];
+    if (getcwd(cwd, sizeof(cwd)) != NULL) {
+      setenv( "OWD", cwd, 1 );
+    }
+
     execv (filename, real_argv);
     /* Error if we continue here */
     perror ("execv error: ");


### PR DESCRIPTION
The place from where the appImage is executed might not be the same
location where its placed.

Consider an appImage located in `/opt/myapp.AppImage`. If I call such
appImage from a terminal emulator where my `$CWD` is `/home/jviotti`
(e.g: by passing the absolute path to the appImage), the application has
no way to determine that it was run from `/home/jviotti`.

This is very useful to provide a better integration when your
application is executed from a terminal emulator. Classic GNU/Linux
applications, like GIMP, set the default location of file dialogs to the
place where the `gimp` command was executed from.

In order to expose this to the user, we set the `OWD` environment to
the result of `getcwd()` right before the runtime passes control to
`AppRun`.

Fixes: https://github.com/probonopd/AppImageKit/issues/172
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>