### PR TITLE
Copy runtime to out directory when building

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -69,7 +69,7 @@ outdir="$PWD/out"
 
 mkdir -p "$outdir"
 
-for i in AppRun; do
+for i in AppRun runtime; do
 	[ -f "$i" ] && cp -v "$i" "${outdir}/${i}_${version}-$(uname -m)"
 done
 


### PR DESCRIPTION
It might be useful to have a pre-compiled runtime available in GitHub releases.

When working on [AppImager](https://github.com/eloquentstore/appimager), I've had to copy the source code for the runtime over to my repository, which I'd rather was just downloaded straight from the AppImage GitHub page.

I'm assuming the changes I've made will release the runtime file to GitHub releases, but please correct me if I'm wrong.

Figured this might be useful for others too.