### PR TITLE
Fix apprun filter segfault

### DIFF
--- a/AppRun.c
+++ b/AppRun.c
@@ -53,10 +53,9 @@ THE SOFTWARE.
 int filter (const struct dirent *dir)
 {
     char *p = (char*) &dir->d_name;
-    while (*++p);
-    while (*--p != '.');
+    p = strrchr(p, '.');
 
-    return !strcmp(p, ".desktop");
+    return p && !strcmp(p, ".desktop");
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
Otherwise `filter` reads past `dir->d_name` when it does not contain a dot.