### PR TITLE
elf.c: in read_elf32, compare read size against ehdr32 instead of ehdr.

### DIFF
--- a/elf.c
+++ b/elf.c
@@ -49,7 +49,7 @@ static unsigned long read_elf32(int fd)
 	ssize_t ret;
 
 	ret = pread(fd, &ehdr32, sizeof(ehdr32), 0);
-	if (ret < 0 || (size_t)ret != sizeof(ehdr)) {
+	if (ret < 0 || (size_t)ret != sizeof(ehdr32)) {
 		fprintf(stderr, "Read of ELF header from %s failed: %s\n",
 			fname, strerror(errno));
 		exit(10);


### PR DESCRIPTION
Before this commit, read_elf32 accidently compared the read size
against the global 'ehdr' struct, which is an Elf64 header.