### PR TITLE
Revert "Fix symlink extraction"

### DIFF
--- a/appimagetool.c
+++ b/appimagetool.c
@@ -404,10 +404,6 @@ main (int argc, char *argv[])
         fprintf (stdout, "%s should be packaged as %s\n", source, destination);
         /* Check if the Icon file is how it is expected */
         gchar* icon_name = get_desktop_entry(kf, "Icon");
-        if(! icon_name) {
-            fprintf (stderr, "Desktop file must define an icon\n");
-            exit(1);
-        }
         gchar* icon_file_path;
         gchar* icon_file_png;
         gchar* icon_file_svg;
@@ -455,8 +451,8 @@ main (int argc, char *argv[])
                     sprintf (command, "%s appdata-from-desktop %s %s", g_find_program_in_path ("appstream-util"), desktop_file, appdata_path);
                     int ret = system(command);
                     if (ret != 0)
-                        die("Failed to generate AppStream template");
-                    fprintf (stderr, "AppStream template has been generated in %s, please edit it\n", appdata_path);
+                        die("Failed to generate a template");
+                    fprintf (stderr, "A template has been generated in in %s, please edit it\n", appdata_path);
                     exit(1);
                 }
             } else {

--- a/elf.c
+++ b/elf.c
@@ -65,12 +65,10 @@ static unsigned long read_elf32(int fd)
 static unsigned long read_elf64(int fd)
 {
 	Elf64_Ehdr ehdr64;
-	Elf64_Shdr shdr64;
-	off_t offset;
 	ssize_t ret;
 
 	ret = pread(fd, &ehdr64, sizeof(ehdr64), 0);
-	if (ret < 0 || (size_t)ret != sizeof(ehdr64)) {
+	if (ret < 0 || (size_t)ret != sizeof(ehdr)) {
 		fprintf(stderr, "Read of ELF header from %s failed: %s\n",
 			fname, strerror(errno));
 		exit(10);
@@ -80,19 +78,11 @@ static unsigned long read_elf64(int fd)
 	ehdr.e_shentsize	= file16_to_cpu(ehdr64.e_shentsize);
 	ehdr.e_shnum		= file16_to_cpu(ehdr64.e_shnum);
 
-	offset = ehdr.e_shoff + (ehdr.e_shentsize * (ehdr.e_shnum - 1));
-	ret = pread(fd, &shdr64, sizeof(shdr64), offset);
-	if (ret < 0 || (size_t)ret != sizeof(shdr64)) {
-		fprintf(stderr, "Read of ELF section header from %s failed: %s\n",
-			fname, strerror(errno));
-		exit(10);
-	}
-
-	return(file64_to_cpu(shdr64.sh_offset) + file64_to_cpu(shdr64.sh_size));
+	return(ehdr.e_shoff + (ehdr.e_shentsize * ehdr.e_shnum));
 }
 
 unsigned long get_elf_size(const char *fname)
-/* TODO, FIXME: With 32 bit runtime, this assumes that the section header table (SHT) is
+/* TODO, FIXME: This assumes that the section header table (SHT) is
 the last part of the ELF. This is usually the case but
 it could also be that the last section is the last part
 of the ELF. This should be checked for.

--- a/runtime.c
+++ b/runtime.c
@@ -248,8 +248,7 @@ main (int argc, char *argv[])
                         fclose(f);
                         chmod (prefixed_path_to_extract, st.st_mode);
                     } else if(inode.base.inode_type == SQUASHFS_SYMLINK_TYPE){
-                        size_t size;
-                        sqfs_readlink(&fs, &inode, NULL, &size);
+                        size_t size = strlen(trv.path)+1;
                         char buf[size];
                         int ret = sqfs_readlink(&fs, &inode, buf, &size);
                         if (ret != 0)


### PR DESCRIPTION
Reverts probonopd/AppImageKit#281 in an effort to find the cause of #282 even though this PR was not causing it. Need to re-apply it.