### PR TITLE
Revert "elf.c: in read_elf32, compare read size against ehdr32 instead of ehdr."

### DIFF
--- a/elf.c
+++ b/elf.c
@@ -49,7 +49,7 @@ static unsigned long read_elf32(int fd)
 	ssize_t ret;
 
 	ret = pread(fd, &ehdr32, sizeof(ehdr32), 0);
-	if (ret < 0 || (size_t)ret != sizeof(ehdr32)) {
+	if (ret < 0 || (size_t)ret != sizeof(ehdr)) {
 		fprintf(stderr, "Read of ELF header from %s failed: %s\n",
 			fname, strerror(errno));
 		exit(10);


### PR DESCRIPTION
Reverts probonopd/AppImageKit#278 in an effort to find the cause for #282