### PR TITLE
Build 32-bit appimagetool and appimaged in Travis CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ services:
   - docker
  
 env:
-# - DOCKER_IMAGE=toopher/centos-i386:centos6 # Pull request welcome that makes this work
-  - DOCKER_IMAGE=library/centos:6.8
+  - ARCH=i686 DOCKER_IMAGE=toopher/centos-i386:centos6
+  - ARCH=x86_64 DOCKER_IMAGE=library/centos:6.8
  
 script:
   - rm -rf data.tar.g* .gnu* || true
@@ -19,8 +19,12 @@ script:
   - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
   - find ./out/appimagetool.AppDir/
   - find ./out/appimaged.AppDir/
-  - ( cd out/ ; ./appimagetool.AppDir/AppRun ./appimagetool.AppDir/ -s -v -u "zsync|https://github.com/probonopd/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage.zsync" )
-  - ( cd out/ ; ./appimagetool-x86_64.AppImage ./appimaged.AppDir/ -s -v -u "zsync|https://github.com/probonopd/AppImageKit/releases/download/continuous/appimaged-x86_64.AppImage.zsync" )
+  - docker run --cap-add SYS_ADMIN --device /dev/fuse:/dev/fuse:mrw -i -v ${PWD}/out:/out -v $HOME/.gnupg:/root/.gnupg "$DOCKER_IMAGE" /bin/bash -c 
+      "yum -y install fuse fuse-libs && 
+      cd /out && 
+      ./appimagetool.AppDir/AppRun ./appimagetool.AppDir/ -s -v -u \"zsync|https://github.com/probonopd/AppImageKit/releases/download/continuous/appimagetool-$ARCH.AppImage.zsync\"
+      appimagetool-$ARCH.AppImage &&
+      ./appimagetool-$ARCH.AppImage ./appimaged.AppDir/ -s -v -u \"zsync|https://github.com/probonopd/AppImageKit/releases/download/continuous/appimaged-$ARCH.AppImage.zsync\" appimaged-$ARCH.AppImage"
   - sudo apt-get install equivs
   - ( cd out ; equivs-build ../appimaged.ctl )
   - rm -rf out/appimaged out/appimagetool out/validate out/digest out/mksquashfs || true

--- a/getsection.c
+++ b/getsection.c
@@ -11,12 +11,21 @@ int get_elf_section_offset_and_lenghth(char* fname, char* section_name, unsigned
 {
     uint8_t *data;   
     int i;  
-    Elf64_Ehdr *elf;
-    Elf64_Shdr *shdr;
     int fd = open(fname, O_RDONLY);
     data = mmap(NULL, lseek(fd, 0, SEEK_END), PROT_READ, MAP_SHARED, fd, 0);
+
+#ifdef __i386__
+    Elf32_Ehdr *elf;
+    Elf32_Shdr *shdr;
+    elf = (Elf32_Ehdr *) data;
+    shdr = (Elf32_Shdr *) (data + elf->e_shoff);
+#else // Default to x86_64
+    Elf64_Ehdr *elf;
+    Elf64_Shdr *shdr;
     elf = (Elf64_Ehdr *) data;
     shdr = (Elf64_Shdr *) (data + elf->e_shoff);
+#endif
+
     char *strTab = (char *)(data + shdr[elf->e_shstrndx].sh_offset);
     for(i = 0; i <  elf->e_shnum; i++) {
         if(strcmp(&strTab[shdr[i].sh_name], section_name) == 0) {


### PR DESCRIPTION
This commit builds both appimagetool and appimaged inside a 32-bit
CentOS container in Travis CI.

Some notes:

- The `install-build-deps.sh` script has been heavily modified to
  correctly install 32-bit dependencies on both Ubuntu and CentOS (which
  doesn't support `devtoolset` in 32-bit).

- AppImage generation now runs inside a Docker container. As a
  consequence, we had to pass `--cap-add SYS_ADMIN --device
  /dev/fuse:/dev/fuse:mrw` to make FUSE work fine inside the container.

- `$HOME/.gnupg` is mapped to `/root/.gnupg` in the container to
  correctly handle GPG signing.

See: #304
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>