### PR TITLE
disable desktop integ. question per app; add uninstall option

### DIFF
--- a/desktopintegration
+++ b/desktopintegration
@@ -60,11 +60,20 @@ if [ -z $APPDIR ] ; then
   APPDIR=$(find-up "AppRun")
 fi
 
-# echo "$APPDIR"
-
 FILENAME="$(readlink -f "${THIS}")"
+DIRNAME=$(dirname $FILENAME)
 
-# echo "$FILENAME"
+DESKTOPFILE=$(find "$APPDIR" -maxdepth 1 -name "*.desktop" | head -n 1)
+DESKTOPFILE_NAME=$(basename "${DESKTOPFILE}")
+
+APP_FULL=$(sed -n -e 's/^Name=//p' "${DESKTOPFILE}" | head -n 1)
+APP=$(echo "$APP_FULL" | tr -c -d '[:alnum:]')
+if [ -z "$APP" ] || [ -z "$APP_FULL" ] ; then
+  APP=$(echo "$DESKTOPFILE_NAME" | sed -e 's/.desktop//g')
+  APP_FULL="$APP"
+fi
+
+RETURN="yes"
 
 if [[ "$FILENAME" != *.wrapper ]] ; then
   echo "${THIS} is not named correctly. It should be named \$Exec.wrapper"
@@ -85,11 +94,13 @@ trap atexit EXIT
 # http://stackoverflow.com/questions/3190818
 atexit()
 {
-if [ $NUMBER_OF_ARGS -eq 0 ] ; then
-  exec "${BIN}"
-else
-  exec "${BIN}" "${args[@]}"
-fi
+  if [ -z "$SKIP" ] ; then
+    if [ $NUMBER_OF_ARGS -eq 0 ] ; then
+      exec "${BIN}"
+    else
+      exec "${BIN}" "${args[@]}"
+    fi
+  fi
 }
 
 error()
@@ -111,11 +122,11 @@ yesno()
   TITLE=$1
   TEXT=$2
   if [ -x /usr/bin/zenity ] ; then
-    LD_LIBRARY_PATH="" zenity --question --title="$TITLE" --text="$TEXT" 2>/dev/null || exit 0
+    LD_LIBRARY_PATH="" zenity --question --title="$TITLE" --text="$TEXT" 2>/dev/null && RETURN="yes" || RETURN="no"
   elif [ -x /usr/bin/kdialog ] ; then
-    LD_LIBRARY_PATH="" kdialog --caption "" --title "$TITLE" -yesno "$TEXT" || exit 0
+    LD_LIBRARY_PATH="" kdialog --caption "" --title "$TITLE" -yesno "$TEXT" && RETURN="yes" || RETURN="no"
   elif [ -x /usr/bin/Xdialog ] ; then
-    LD_LIBRARY_PATH="" Xdialog --title "$TITLE" --clear --yesno "$TEXT" 10 80 || exit 0
+    LD_LIBRARY_PATH="" Xdialog --title "$TITLE" --clear --yesno "$TEXT" 10 80 && RETURN="yes" || RETURN="no"
   else
     echo "zenity, kdialog, Xdialog missing. Skipping ${THIS}."
     exit 0
@@ -130,7 +141,37 @@ check_prevent()
   fi
 }
 
-# Exit immediately of one of these files is present
+check_dep()
+{
+  DEP=$1
+  if [ -z $(which $DEP) ] ; then
+    echo "$DEP is missing. Skipping ${THIS}."
+    exit 0
+  fi
+}
+
+# Determine where the desktop file should be installed
+if [[ $EUID -ne 0 ]]; then
+   DESTINATION_DIR_DESKTOP="$HOME/.local/share/applications"
+   STAMP_DIR="$HOME/.local/share/$VENDORPREFIX"
+   SYSTEM_WIDE=""
+else
+   # TODO: Check $XDG_DATA_DIRS
+   DESTINATION_DIR_DESKTOP="/usr/local/share/applications"
+   STAMP_DIR="/etc/$VENDORPREFIX"
+   SYSTEM_WIDE="--mode system" # for xdg-mime and xdg-icon-resource
+fi
+
+# Remove desktop integration for this AppImage
+if [ "x$1" = "x--remove-appimage-desktop-integration" ] ; then
+  SKIP="yes"
+  rm -f "$STAMP_DIR/${APP}_no_desktopintegration" "$DESTINATION_DIR_DESKTOP/$VENDORPREFIX-$DESKTOPFILE_NAME"
+  check_dep xdg-desktop-menu
+  xdg-desktop-menu forceupdate
+  exit 0
+fi
+
+# Exit immediately if one of these files is present
 # (e.g., because the desktop environment wants to handle desktop integration itself)
 check_prevent "$HOME/.local/share/$VENDORPREFIX/no_desktopintegration"
 check_prevent "/usr/share/$VENDORPREFIX/no_desktopintegration"
@@ -144,17 +185,6 @@ if [ ! -z "$DESKTOPINTEGRATION" ] ; then
   exit 0
 fi
 
-check_dep()
-{
-  DEP=$1
-  if [ -z $(which $DEP) ] ; then
-    echo "$DEP is missing. Skipping ${THIS}."
-    exit 0
-  fi
-}
-
-DIRNAME=$(dirname $FILENAME)
-
 # Check whether dependencies are present in base system (we do not bundle these)
 # http://cgit.freedesktop.org/xdg/desktop-file-utils/
 check_dep desktop-file-validate
@@ -164,9 +194,10 @@ check_dep xdg-icon-resource
 check_dep xdg-mime
 check_dep xdg-desktop-menu
 
-DESKTOPFILE=$(find "$APPDIR" -maxdepth 1 -name "*.desktop" | head -n 1)
-# echo "$DESKTOPFILE"
-DESKTOPFILE_NAME=$(basename "${DESKTOPFILE}")
+# Exit immediately if one of these files is present (disabled per app)
+check_prevent "$HOME/.local/share/$VENDORPREFIX/${APP}_no_desktopintegration"
+check_prevent "/usr/share/$VENDORPREFIX/${APP}_no_desktopintegration"
+check_prevent "/etc/$VENDORPREFIX/${APP}_no_desktopintegration"
 
 if [ ! -f "$DESKTOPFILE" ] ; then
   echo "Desktop file is missing. Please run ${THIS} from within an AppImage."
@@ -188,16 +219,6 @@ if [ -z "$XDG_DATA_DIRS" ] ; then
   exit 0
 fi
 
-# Determine where the desktop file should be installed
-if [[ $EUID -ne 0 ]]; then
-   DESTINATION_DIR_DESKTOP="$HOME/.local/share/applications"
-   SYSTEM_WIDE=""
-else
-   # TODO: Check $XDG_DATA_DIRS
-   DESTINATION_DIR_DESKTOP="/usr/local/share/applications"
-   SYSTEM_WIDE="--mode system" # for xdg-mime and xdg-icon-resource
-fi
-
 # Check if the desktop file is already there
 # and if so, whether it points to the same AppImage
 if [ -e "$DESTINATION_DIR_DESKTOP/$VENDORPREFIX-$DESKTOPFILE_NAME" ] ; then
@@ -214,7 +235,14 @@ if [ -z "$SKIP" ] ; then
   yesno "Install" "Would you like to integrate $APPIMAGE with your system?\n\nThis will add it to your applications menu and install icons.\nIf you don't do this you can still launch the application by double-clicking on the AppImage."
 fi
 
-APP=$(echo "$DESKTOPFILE_NAME" | sed -e 's/.desktop//g')
+if [ "$RETURN" = "no" ] ; then
+  yesno "Disable question?" "Should this question be permanently disabled for $APP?\n\nTo re-enable this question you have to delete\n\"$STAMP_DIR/${APP}_no_desktopintegration\""
+  if [ "$RETURN" = "yes" ] ; then
+    mkdir -p "$STAMP_DIR"
+    touch "$STAMP_DIR/${APP}_no_desktopintegration"
+  fi
+  exit 0
+fi
 
 # If the user has agreed, rewrite and install the desktop file, and the MIME information
 if [ -z "$SKIP" ] ; then
@@ -234,6 +262,18 @@ if [ -z "$SKIP" ] ; then
     --dir "$DESTINATION_DIR_DESKTOP"
   chmod a+x "$DESTINATION_DIR_DESKTOP/"*
   # echo $RESOURCE_NAME
+
+  # delete "Actions" entry and add an "Uninstall" action
+  sed -i -e '/^Actions=/d' "$DESTINATION_DIR_DESKTOP/$VENDORPREFIX-$DESKTOPFILE_NAME"
+  cat >> "$DESTINATION_DIR_DESKTOP/$VENDORPREFIX-$DESKTOPFILE_NAME" << EOF
+
+Actions=Uninstall;
+
+[Uninstall]
+Name=Remove desktop integration for $APP_FULL
+Exec="$APPIMAGE" --remove-appimage-desktop-integration
+
+EOF
 
   # Install the icon files for the application; TODO: scalable
   ICONS=$(find "${APPDIR}/usr/share/icons/" -wholename "*/apps/${APP}.png" 2>/dev/null || true)


### PR DESCRIPTION
 * Added an option to disable the desktop integration question only for one app
 * Desktop menu entries can now be removed by running the AppImage with `--remove-appimage-desktop-integration` or by chosing "Uninstall" from the desktop menu entries context menu (not available on MATE and maybe some other DEs)