### PR TITLE
Convert hex to ascii for the filename

### DIFF
--- a/AppImageUpdate.AppDir/usr/bin/appimageupdate
+++ b/AppImageUpdate.AppDir/usr/bin/appimageupdate
@@ -149,7 +149,7 @@ if [ "$TYPE" == "zsync" ] ; then
   # Get the file with zsync using $1 as an input file
   zsync_curl -I -i "${ISO}" "${ZSYNC_URL}" 2>&1
   NEWFILE=$(basename "${ZSYNC_URL}" | sed -e 's|.zsync||g' ) # FIXME: Use the file that zsync has written!!!
-  chmod --reference="${ISO}.zs-old" "${NEWFILE}" # Set the same permissions as for the original file
+  chmod --reference="${ISO}.zs-old" "$(printf '%b' "${NEWFILE//%/\\x}")" # Set the same permissions as for the original file
   gpg_check
 elif [ "$TYPE" == "bintray-zsync" ] ; then
   cd $(dirname "${ISO}") 
@@ -179,7 +179,7 @@ elif [ "$TYPE" == "bintray-zsync" ] ; then
   # Get the file with zsync using $1 as an input file
   zsync_curl -I -i "${ISO}" "${ZSYNC_URL}" 2>&1
   NEWFILE=$(basename "${ZSYNC_URL}" | sed -e 's|.zsync||g' ) # FIXME: Use the file that zsync has written!!!
-  chmod --reference="${ISO}" "${NEWFILE}" # Set the same permissions as for the original file
+  chmod --reference="${ISO}" "$(printf '%b' "${NEWFILE//%/\\x}")" # Set the same permissions as for the original file
   gpg_check
 
 elif [ "$TYPE" == "" ] ; then


### PR DESCRIPTION
The filename contains hex so chmod doesn't work. Should fix :

chmod: cannot access 'RetroArch-1.3.6%2Br487.glibc2.17-x86_64.AppImage': No such file or directory

The filename should be RetroArch-1.3.6+r487.glibc2.17-x86_64.AppImage