### PR TITLE
Add sys/wait.h include to appimagetool.c for WEXITSTATUS.

### DIFF
--- a/appimagetool.c
+++ b/appimagetool.c
@@ -38,6 +38,7 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
 
 #include "binreloc.h"
 #ifndef NULL


### PR DESCRIPTION
Fixes CentOS 5 build.