### PR TITLE
exit immediately if libfuse is needed but not found

### DIFF
--- a/runtime.c
+++ b/runtime.c
@@ -49,6 +49,11 @@
 #include "elf.h"
 #include "getsection.h"
 
+#ifndef ENABLE_DLOPEN
+#define ENABLE_DLOPEN
+#endif
+#include "squashfuse_dlopen.h"
+
 #include <fnmatch.h>
 
 //#include "notify.c"
@@ -343,7 +348,9 @@ main (int argc, char *argv[])
         print_binary(appimage_path, offset, length);
         exit(0);
     }
-    
+
+    LOAD_LIBRARY; /* exit if libfuse is missing */
+
     int dir_fd, res;
     char mount_dir[] = "/tmp/.mount_XXXXXX";  /* create mountpoint */
     char filename[100]; /* enough for mount_dir + "/AppRun" */
@@ -409,8 +416,6 @@ main (int argc, char *argv[])
         dir_fd = open (mount_dir, O_RDONLY);
         if (dir_fd == -1) {
             perror ("open dir error");
-            /* TODO: dlopen() libfuse and be nice if it is not there, e.g., offer
-             * to extract the files to a temp location and run AppRun */
             exit (1);
         }
         

--- a/squashfuse_dlopen.h
+++ b/squashfuse_dlopen.h
@@ -27,12 +27,10 @@ void *libhandle;
 int have_libloaded;
 const char *load_library_errmsg;
 
-#define CLOSE_LIBRARY dlclose(libhandle);
-
 #define LOAD_LIBRARY \
 if (have_libloaded != 1) { \
   if (!(libhandle = dlopen(LIBNAME, RTLD_LAZY))) { \
-    fprintf(stderr, "dlopen(): error loading " LIBNAME "\n%s\n", load_library_errmsg ); \
+    fprintf(stderr, "dlopen(): error loading " LIBNAME "\n\n%s", load_library_errmsg ); \
     exit(1); \
   } else { \
     have_libloaded = 1; \
@@ -40,15 +38,18 @@ if (have_libloaded != 1) { \
 }
 
 #define STRINGIFY(x) #x
+
 #define LOAD_SYMBOL(type,x,param) \
-LOAD_LIBRARY; \
 type (*dl_##x) param; \
 *(void **) (&dl_##x) = dlsym(libhandle, STRINGIFY(x)); \
 if (dlerror()) { \
-  fprintf(stderr, "dlsym(): error loading symbol from " LIBNAME "\n%s\n", load_library_errmsg ); \
+  fprintf(stderr, "dlsym(): error loading symbol from " LIBNAME "\n\n%s", load_library_errmsg ); \
   CLOSE_LIBRARY; \
   exit(1); \
 }
+
+#define DL(x) dl_##x
+#define CLOSE_LIBRARY dlclose(libhandle);
 
 
 /*** libfuse stuff ***/
@@ -250,7 +251,9 @@ struct fuse_lowlevel_ops {
 
 #else  /* !ENABLE_DLOPEN */
 
+#define LOAD_LIBRARY
 #define LOAD_SYMBOL(x)
+#define DL(x)
 #define CLOSE_LIBRARY
 
 #endif  /* !ENABLE_DLOPEN */

--- a/squashfuse_dlopen.patch
+++ b/squashfuse_dlopen.patch
@@ -31,8 +31,8 @@
  }
  
  void sqfs_usage(char *progname, bool fuse_usage) {
-+  LOAD_SYMBOL(int,fuse_opt_add_arg,(struct fuse_args *args, const char *arg));
-+  LOAD_SYMBOL(int,fuse_parse_cmdline,(struct fuse_args *args, char **mountpoint, int *multithreaded, int *foreground));
++	LOAD_SYMBOL(int,fuse_opt_add_arg,(struct fuse_args *args, const char *arg));
++	LOAD_SYMBOL(int,fuse_parse_cmdline,(struct fuse_args *args, char **mountpoint, int *multithreaded, int *foreground));
  	fprintf(stderr, "%s (c) 2012 Dave Vasilevsky\n\n", PACKAGE_STRING);
  	fprintf(stderr, "Usage: %s [options] ARCHIVE MOUNTPOINT\n",
  		progname ? progname : PACKAGE_NAME);
@@ -40,11 +40,11 @@
  		struct fuse_args args = FUSE_ARGS_INIT(0, NULL);
 -		fuse_opt_add_arg(&args, ""); /* progname */
 -		fuse_opt_add_arg(&args, "-ho");
-+		dl_fuse_opt_add_arg(&args, ""); /* progname */
-+		dl_fuse_opt_add_arg(&args, "-ho");
++		DL(fuse_opt_add_arg)(&args, ""); /* progname */
++		DL(fuse_opt_add_arg)(&args, "-ho");
  		fprintf(stderr, "\n");
 -		fuse_parse_cmdline(&args, NULL, NULL, NULL);
-+		dl_fuse_parse_cmdline(&args, NULL, NULL, NULL);
++		DL(fuse_parse_cmdline)(&args, NULL, NULL, NULL);
  	}
  	exit(-2);
  }
@@ -57,7 +57,7 @@
 -#include <fuse.h>
 +#include "squashfuse_dlopen.h"
 +#ifndef ENABLE_DLOPEN
-+# include <fuse.h>
++#	include <fuse.h>
 +#endif
  
  #include <sys/stat.h>
@@ -76,11 +76,11 @@
  
  static sqfs_err sqfs_hl_lookup(sqfs **fs, sqfs_inode *inode,
  		const char *path) {
-+  LOAD_SYMBOL(struct fuse_context *,fuse_get_context,(void));
++	LOAD_SYMBOL(struct fuse_context *,fuse_get_context,(void));
  	bool found;
  	
 -	sqfs_hl *hl = fuse_get_context()->private_data;
-+	sqfs_hl *hl = dl_fuse_get_context()->private_data;
++	sqfs_hl *hl = DL(fuse_get_context)()->private_data;
  	*fs = &hl->fs;
  	if (inode)
  		*inode = hl->root; /* copy */
@@ -89,8 +89,8 @@
  
  static void *sqfs_hl_op_init(struct fuse_conn_info *conn) {
 -	return fuse_get_context()->private_data;
-+  LOAD_SYMBOL(struct fuse_context *,fuse_get_context,(void));
-+	return dl_fuse_get_context()->private_data;
++	LOAD_SYMBOL(struct fuse_context *,fuse_get_context,(void));
++	return DL(fuse_get_context)()->private_data;
  }
  
  static int sqfs_hl_op_getattr(const char *path, struct stat *st) {
@@ -100,14 +100,14 @@
  
 +#ifdef ENABLE_DLOPEN
 +#define fuse_main(argc, argv, op, user_data) \
-+  dl_fuse_main_real(argc, argv, op, sizeof(*(op)), user_data)
++	DL(fuse_main_real)(argc, argv, op, sizeof(*(op)), user_data)
 +#endif
 +
  int main(int argc, char *argv[]) {
-+  LOAD_SYMBOL(int,fuse_opt_parse,(struct fuse_args *args, void *data, const struct fuse_opt opts[], fuse_opt_proc_t proc));
-+  LOAD_SYMBOL(int,fuse_opt_add_arg,(struct fuse_args *args, const char *arg));
-+  LOAD_SYMBOL(int,fuse_main_real,(int argc, char *argv[], const struct fuse_operations *op, size_t op_size, void *user_data));  /* fuse_main */
-+  LOAD_SYMBOL(void,fuse_opt_free_args,(struct fuse_args *args));
++	LOAD_SYMBOL(int,fuse_opt_parse,(struct fuse_args *args, void *data, const struct fuse_opt opts[], fuse_opt_proc_t proc));
++	LOAD_SYMBOL(int,fuse_opt_add_arg,(struct fuse_args *args, const char *arg));
++	LOAD_SYMBOL(int,fuse_main_real,(int argc, char *argv[], const struct fuse_operations *op, size_t op_size, void *user_data));  /* fuse_main */
++	LOAD_SYMBOL(void,fuse_opt_free_args,(struct fuse_args *args));
  	struct fuse_args args;
  	sqfs_opts opts;
  	sqfs_hl *hl;
@@ -116,7 +116,7 @@
  	opts.mountpoint = 0;
  	opts.offset = 0;
 -	if (fuse_opt_parse(&args, &opts, fuse_opts, sqfs_opt_proc) == -1)
-+	if (dl_fuse_opt_parse(&args, &opts, fuse_opts, sqfs_opt_proc) == -1)
++	if (DL(fuse_opt_parse)(&args, &opts, fuse_opts, sqfs_opt_proc) == -1)
  		sqfs_usage(argv[0], true);
  	if (!opts.image)
  		sqfs_usage(argv[0], true);
@@ -125,11 +125,11 @@
  		return -1;
  	
 -	fuse_opt_add_arg(&args, "-s"); /* single threaded */
-+	dl_fuse_opt_add_arg(&args, "-s"); /* single threaded */
++	DL(fuse_opt_add_arg)(&args, "-s"); /* single threaded */
  	ret = fuse_main(args.argc, args.argv, &sqfs_hl_ops, hl);
 -	fuse_opt_free_args(&args);
-+	dl_fuse_opt_free_args(&args);
-+  CLOSE_LIBRARY;
++	DL(fuse_opt_free_args)(&args);
++	CLOSE_LIBRARY;
  	return ret;
  }
 --- a/ll.h
@@ -141,7 +141,7 @@
 -#include <fuse_lowlevel.h>
 +#include "squashfuse_dlopen.h"
 +#ifndef ENABLE_DLOPEN
-+# include <fuse_lowlevel.h>
++#	include <fuse_lowlevel.h>
 +#endif
  
  typedef struct sqfs_ll sqfs_ll;
@@ -152,16 +152,16 @@
  
  
  sqfs_err sqfs_ll_iget(fuse_req_t req, sqfs_ll_i *lli, fuse_ino_t i) {
-+  LOAD_SYMBOL(void *,fuse_req_userdata,(fuse_req_t req));
-+  LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
++	LOAD_SYMBOL(void *,fuse_req_userdata,(fuse_req_t req));
++	LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
  	sqfs_err err = SQFS_OK;
 -	lli->ll = fuse_req_userdata(req);
-+	lli->ll = dl_fuse_req_userdata(req);
++	lli->ll = DL(fuse_req_userdata)(req);
  	if (i != SQFS_FUSE_INODE_NONE) {
  		err = sqfs_ll_inode(lli->ll, &lli->inode, i);
  		if (err)
 -			fuse_reply_err(req, ENOENT);
-+			dl_fuse_reply_err(req, ENOENT);
++			DL(fuse_reply_err)(req, ENOENT);
  	}
  	return err;
  }
@@ -175,14 +175,14 @@
 +
 +#include "squashfuse_dlopen.h"
 +#ifndef ENABLE_DLOPEN
-+# include <fuse_lowlevel.h>
++#	include <fuse_lowlevel.h>
 +#endif
  
  int sqfs_ll_daemonize(int fg) {
  	#if HAVE_DECL_FUSE_DAEMONIZE
 -		return fuse_daemonize(fg);
-+    LOAD_SYMBOL(int,fuse_daemonize,(int foreground));
-+		return dl_fuse_daemonize(fg);
++		LOAD_SYMBOL(int,fuse_daemonize,(int foreground));
++		return DL(fuse_daemonize)(fg);
  	#else
  		return daemon(0,0);
  	#endif
@@ -192,8 +192,8 @@
  
  static void sqfs_ll_op_getattr(fuse_req_t req, fuse_ino_t ino,
  		struct fuse_file_info *fi) {
-+  LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
-+  LOAD_SYMBOL(int,fuse_reply_attr,(fuse_req_t req, const struct stat *attr, double attr_timeout));
++	LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
++	LOAD_SYMBOL(int,fuse_reply_attr,(fuse_req_t req, const struct stat *attr, double attr_timeout));
  	sqfs_ll_i lli;
  	struct stat st;
  	if (sqfs_ll_iget(req, &lli, ino))
@@ -201,18 +201,18 @@
  	
  	if (sqfs_stat(&lli.ll->fs, &lli.inode, &st)) {
 -		fuse_reply_err(req, ENOENT);
-+		dl_fuse_reply_err(req, ENOENT);
++		DL(fuse_reply_err)(req, ENOENT);
  	} else {
  		st.st_ino = ino;
 -		fuse_reply_attr(req, &st, SQFS_TIMEOUT);
-+		dl_fuse_reply_attr(req, &st, SQFS_TIMEOUT);
++		DL(fuse_reply_attr)(req, &st, SQFS_TIMEOUT);
  	}
  }
  
  static void sqfs_ll_op_opendir(fuse_req_t req, fuse_ino_t ino,
  		struct fuse_file_info *fi) {
-+  LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
-+  LOAD_SYMBOL(int,fuse_reply_open,(fuse_req_t req, const struct fuse_file_info *fi));
++	LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
++	LOAD_SYMBOL(int,fuse_reply_open,(fuse_req_t req, const struct fuse_file_info *fi));
  	sqfs_ll_i *lli;
  	
  	fi->fh = (intptr_t)NULL;
@@ -220,18 +220,18 @@
  	lli = malloc(sizeof(*lli));
  	if (!lli) {
 -		fuse_reply_err(req, ENOMEM);
-+		dl_fuse_reply_err(req, ENOMEM);
++		DL(fuse_reply_err)(req, ENOMEM);
  		return;
  	}
  	
  	if (sqfs_ll_iget(req, lli, ino) == SQFS_OK) {
  		if (!S_ISDIR(lli->inode.base.mode)) {
 -			fuse_reply_err(req, ENOTDIR);
-+			dl_fuse_reply_err(req, ENOTDIR);
++			DL(fuse_reply_err)(req, ENOTDIR);
  		} else {
  			fi->fh = (intptr_t)lli;
 -			fuse_reply_open(req, fi);
-+			dl_fuse_reply_open(req, fi);
++			DL(fuse_reply_open)(req, fi);
  			return;
  		}
  	}
@@ -240,39 +240,39 @@
  static void sqfs_ll_op_create(fuse_req_t req, fuse_ino_t parent, const char *name,
  			      mode_t mode, struct fuse_file_info *fi) {
 -	fuse_reply_err(req, EROFS);
-+  LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
-+	dl_fuse_reply_err(req, EROFS);
++	LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
++	DL(fuse_reply_err)(req, EROFS);
  }
  
  static void sqfs_ll_op_releasedir(fuse_req_t req, fuse_ino_t ino,
  		struct fuse_file_info *fi) {
  	free((sqfs_ll_i*)(intptr_t)fi->fh);
 -	fuse_reply_err(req, 0); /* yes, this is necessary */
-+  LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
-+	dl_fuse_reply_err(req, 0); /* yes, this is necessary */
++	LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
++	DL(fuse_reply_err)(req, 0); /* yes, this is necessary */
  }
  
  static size_t sqfs_ll_add_direntry(fuse_req_t req, char *buf, size_t bufsize,
  		const char *name, const struct stat *st, off_t off) {
  	#if HAVE_DECL_FUSE_ADD_DIRENTRY
 -		return fuse_add_direntry(req, buf, bufsize, name, st, off);
-+    LOAD_SYMBOL(size_t,fuse_add_direntry,(fuse_req_t req, char *buf, size_t bufsize, const char *name, const struct stat *stbuf, off_t off));
-+		return dl_fuse_add_direntry(req, buf, bufsize, name, st, off);
++		LOAD_SYMBOL(size_t,fuse_add_direntry,(fuse_req_t req, char *buf, size_t bufsize, const char *name, const struct stat *stbuf, off_t off));
++		return DL(fuse_add_direntry)(req, buf, bufsize, name, st, off);
  	#else
 -		size_t esize = fuse_dirent_size(strlen(name));
-+    LOAD_SYMBOL(size_t,fuse_dirent_size(size_t namelen));
-+    LOAD_SYMBOL(char *,fuse_add_dirent,(char *buf, const char *name, const struct stat *stbuf, off_t off));
-+		size_t esize = dl_fuse_dirent_size(strlen(name));
++		LOAD_SYMBOL(size_t,fuse_dirent_size(size_t namelen));
++		LOAD_SYMBOL(char *,fuse_add_dirent,(char *buf, const char *name, const struct stat *stbuf, off_t off));
++		size_t esize = DL(fuse_dirent_size)(strlen(name));
  		if (bufsize >= esize)
 -			fuse_add_dirent(buf, name, st, off);
-+			dl_fuse_add_dirent(buf, name, st, off);
++			DL(fuse_add_dirent)(buf, name, st, off);
  		return esize;
  	#endif
  }
  static void sqfs_ll_op_readdir(fuse_req_t req, fuse_ino_t ino, size_t size,
  		off_t off, struct fuse_file_info *fi) {
-+  LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
-+  LOAD_SYMBOL(int,fuse_reply_buf,(fuse_req_t req, const char *buf, size_t size));
++	LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
++	LOAD_SYMBOL(int,fuse_reply_buf,(fuse_req_t req, const char *buf, size_t size));
  	sqfs_err sqerr;
  	sqfs_dir dir;
  	sqfs_name namebuf;
@@ -281,17 +281,17 @@
  	
  	if (err)
 -		fuse_reply_err(req, err);
-+		dl_fuse_reply_err(req, err);
++		DL(fuse_reply_err)(req, err);
  	else
 -		fuse_reply_buf(req, buf, bufpos - buf);
-+		dl_fuse_reply_buf(req, buf, bufpos - buf);
++		DL(fuse_reply_buf)(req, buf, bufpos - buf);
  	free(buf);
  }
  
  static void sqfs_ll_op_lookup(fuse_req_t req, fuse_ino_t parent,
  		const char *name) {
-+  LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
-+  LOAD_SYMBOL(int,fuse_reply_entry,(fuse_req_t req, const struct fuse_entry_param *e));
++	LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
++	LOAD_SYMBOL(int,fuse_reply_entry,(fuse_req_t req, const struct fuse_entry_param *e));
  	sqfs_ll_i lli;
  	sqfs_err sqerr;
  	sqfs_name namebuf;
@@ -300,7 +300,7 @@
  	
  	if (!S_ISDIR(lli.inode.base.mode)) {
 -		fuse_reply_err(req, ENOTDIR);
-+		dl_fuse_reply_err(req, ENOTDIR);
++		DL(fuse_reply_err)(req, ENOTDIR);
  		return;
  	}
  	
@@ -309,68 +309,68 @@
  		&found);
  	if (sqerr) {
 -		fuse_reply_err(req, EIO);
-+		dl_fuse_reply_err(req, EIO);
++		DL(fuse_reply_err)(req, EIO);
  		return;
  	}
  	if (!found) {
 -		fuse_reply_err(req, ENOENT);
-+		dl_fuse_reply_err(req, ENOENT);
++		DL(fuse_reply_err)(req, ENOENT);
  		return;
  	}
  	
  	if (sqfs_inode_get(&lli.ll->fs, &inode, sqfs_dentry_inode(&entry))) {
 -		fuse_reply_err(req, ENOENT);
-+		dl_fuse_reply_err(req, ENOENT);
++		DL(fuse_reply_err)(req, ENOENT);
  	} else {
  		struct fuse_entry_param fentry;
  		memset(&fentry, 0, sizeof(fentry));
  		if (sqfs_stat(&lli.ll->fs, &inode, &fentry.attr)) {
 -			fuse_reply_err(req, EIO);
-+			dl_fuse_reply_err(req, EIO);
++			DL(fuse_reply_err)(req, EIO);
  		} else {
  			fentry.attr_timeout = fentry.entry_timeout = SQFS_TIMEOUT;
  			fentry.ino = lli.ll->ino_register(lli.ll, &entry);
  			fentry.attr.st_ino = fentry.ino;
 -			fuse_reply_entry(req, &fentry);
-+			dl_fuse_reply_entry(req, &fentry);
++			DL(fuse_reply_entry)(req, &fentry);
  		}
  	}
  }
  
  static void sqfs_ll_op_open(fuse_req_t req, fuse_ino_t ino,
  		struct fuse_file_info *fi) {
-+  LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
-+  LOAD_SYMBOL(int,fuse_reply_open,(fuse_req_t req, const struct fuse_file_info *fi));
-+  LOAD_SYMBOL(void *,fuse_req_userdata,(fuse_req_t req));
++	LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
++	LOAD_SYMBOL(int,fuse_reply_open,(fuse_req_t req, const struct fuse_file_info *fi));
++	LOAD_SYMBOL(void *,fuse_req_userdata,(fuse_req_t req));
  	sqfs_inode *inode;
  	sqfs_ll *ll;
  	
  	if (fi->flags & (O_WRONLY | O_RDWR)) {
 -		fuse_reply_err(req, EROFS);
-+		dl_fuse_reply_err(req, EROFS);
++		DL(fuse_reply_err)(req, EROFS);
  		return;
  	}
  	
  	inode = malloc(sizeof(sqfs_inode));
  	if (!inode) {
 -		fuse_reply_err(req, ENOMEM);
-+		dl_fuse_reply_err(req, ENOMEM);
++		DL(fuse_reply_err)(req, ENOMEM);
  		return;
  	}
  	
 -	ll = fuse_req_userdata(req);
-+	ll = dl_fuse_req_userdata(req);
++	ll = DL(fuse_req_userdata)(req);
  	if (sqfs_ll_inode(ll, inode, ino)) {
 -		fuse_reply_err(req, ENOENT);
-+		dl_fuse_reply_err(req, ENOENT);
++		DL(fuse_reply_err)(req, ENOENT);
  	} else if (!S_ISREG(inode->base.mode)) {
 -		fuse_reply_err(req, EISDIR);
-+		dl_fuse_reply_err(req, EISDIR);
++		DL(fuse_reply_err)(req, EISDIR);
  	} else {
  		fi->fh = (intptr_t)inode;
  		fi->keep_cache = 1;
 -		fuse_reply_open(req, fi);
-+		dl_fuse_reply_open(req, fi);
++		DL(fuse_reply_open)(req, fi);
  		return;
  	}
  	free(inode);
@@ -378,20 +378,20 @@
  
  static void sqfs_ll_op_release(fuse_req_t req, fuse_ino_t ino,
  		struct fuse_file_info *fi) {
-+  LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
++	LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
  	free((sqfs_inode*)(intptr_t)fi->fh);
  	fi->fh = 0;
 -	fuse_reply_err(req, 0);
-+	dl_fuse_reply_err(req, 0);
++	DL(fuse_reply_err)(req, 0);
  }
  
  static void sqfs_ll_op_read(fuse_req_t req, fuse_ino_t ino,
  		size_t size, off_t off, struct fuse_file_info *fi) {
 -	sqfs_ll *ll = fuse_req_userdata(req);
-+  LOAD_SYMBOL(void *,fuse_req_userdata,(fuse_req_t req));
-+  LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
-+  LOAD_SYMBOL(int,fuse_reply_buf,(fuse_req_t req, const char *buf, size_t size));
-+	sqfs_ll *ll = dl_fuse_req_userdata(req);
++	LOAD_SYMBOL(void *,fuse_req_userdata,(fuse_req_t req));
++	LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
++	LOAD_SYMBOL(int,fuse_reply_buf,(fuse_req_t req, const char *buf, size_t size));
++	sqfs_ll *ll = DL(fuse_req_userdata)(req);
  	sqfs_inode *inode = (sqfs_inode*)(intptr_t)fi->fh;
  	sqfs_err err = SQFS_OK;
  	
@@ -399,7 +399,7 @@
  	char *buf = malloc(size);
  	if (!buf) {
 -		fuse_reply_err(req, ENOMEM);
-+		dl_fuse_reply_err(req, ENOMEM);
++		DL(fuse_reply_err)(req, ENOMEM);
  		return;
  	}
  	
@@ -407,20 +407,20 @@
  	err = sqfs_read_range(&ll->fs, inode, off, &osize, buf);
  	if (err) {
 -		fuse_reply_err(req, EIO);
-+		dl_fuse_reply_err(req, EIO);
++		DL(fuse_reply_err)(req, EIO);
  	} else if (osize == 0) { /* EOF */
 -		fuse_reply_buf(req, NULL, 0);
-+		dl_fuse_reply_buf(req, NULL, 0);
++		DL(fuse_reply_buf)(req, NULL, 0);
  	} else {
 -		fuse_reply_buf(req, buf, osize);
-+		dl_fuse_reply_buf(req, buf, osize);
++		DL(fuse_reply_buf)(req, buf, osize);
  	}
  	free(buf);
  }
  
  static void sqfs_ll_op_readlink(fuse_req_t req, fuse_ino_t ino) {
-+  LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
-+  LOAD_SYMBOL(int,fuse_reply_readlink,(fuse_req_t req, const char *link));
++	LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
++	LOAD_SYMBOL(int,fuse_reply_readlink,(fuse_req_t req, const char *link));
  	char *dst;
  	size_t size;
  	sqfs_ll_i lli;
@@ -429,28 +429,28 @@
  	
  	if (!S_ISLNK(lli.inode.base.mode)) {
 -		fuse_reply_err(req, EINVAL);
-+		dl_fuse_reply_err(req, EINVAL);
++		DL(fuse_reply_err)(req, EINVAL);
  	} else if (sqfs_readlink(&lli.ll->fs, &lli.inode, NULL, &size)) {
 -		fuse_reply_err(req, EIO);
-+		dl_fuse_reply_err(req, EIO);
++		DL(fuse_reply_err)(req, EIO);
  	} else if (!(dst = malloc(size + 1))) {
 -		fuse_reply_err(req, ENOMEM);
-+		dl_fuse_reply_err(req, ENOMEM);
++		DL(fuse_reply_err)(req, ENOMEM);
  	} else if (sqfs_readlink(&lli.ll->fs, &lli.inode, dst, &size)) {
 -		fuse_reply_err(req, EIO);
-+		dl_fuse_reply_err(req, EIO);
++		DL(fuse_reply_err)(req, EIO);
  		free(dst);
  	} else {
 -		fuse_reply_readlink(req, dst);
-+		dl_fuse_reply_readlink(req, dst);
++		DL(fuse_reply_readlink)(req, dst);
  		free(dst);
  	}
  }
  
  static void sqfs_ll_op_listxattr(fuse_req_t req, fuse_ino_t ino, size_t size) {
-+  LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
-+  LOAD_SYMBOL(int,fuse_reply_xattr,(fuse_req_t req, size_t count));
-+  LOAD_SYMBOL(int,fuse_reply_buf,(fuse_req_t req, const char *buf, size_t size));
++	LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
++	LOAD_SYMBOL(int,fuse_reply_xattr,(fuse_req_t req, size_t count));
++	LOAD_SYMBOL(int,fuse_reply_buf,(fuse_req_t req, const char *buf, size_t size));
  	sqfs_ll_i lli;
  	char *buf;
  	int ferr;
@@ -459,20 +459,20 @@
  	buf = NULL;
  	if (size && !(buf = malloc(size))) {
 -		fuse_reply_err(req, ENOMEM);
-+		dl_fuse_reply_err(req, ENOMEM);
++		DL(fuse_reply_err)(req, ENOMEM);
  		return;
  	}
  	
  	ferr = sqfs_listxattr(&lli.ll->fs, &lli.inode, buf, &size);
  	if (ferr) {
 -		fuse_reply_err(req, ferr);
-+		dl_fuse_reply_err(req, ferr);
++		DL(fuse_reply_err)(req, ferr);
  	} else if (buf) {
 -		fuse_reply_buf(req, buf, size);
-+		dl_fuse_reply_buf(req, buf, size);
++		DL(fuse_reply_buf)(req, buf, size);
  	} else {
 -		fuse_reply_xattr(req, size);
-+		dl_fuse_reply_xattr(req, size);
++		DL(fuse_reply_xattr)(req, size);
  	}
  	free(buf);
  }
@@ -480,9 +480,9 @@
  		, uint32_t position
  #endif
  		) {
-+  LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
-+  LOAD_SYMBOL(int,fuse_reply_xattr,(fuse_req_t req, size_t count));
-+  LOAD_SYMBOL(int,fuse_reply_buf,(fuse_req_t req, const char *buf, size_t size));
++	LOAD_SYMBOL(int,fuse_reply_err,(fuse_req_t req, int err));
++	LOAD_SYMBOL(int,fuse_reply_xattr,(fuse_req_t req, size_t count));
++	LOAD_SYMBOL(int,fuse_reply_buf,(fuse_req_t req, const char *buf, size_t size));
  	sqfs_ll_i lli;
  	char *buf = NULL;
  	size_t real = size;
@@ -490,7 +490,7 @@
  #ifdef FUSE_XATTR_POSITION
  	if (position != 0) { /* We don't support resource forks */
 -		fuse_reply_err(req, EINVAL);
-+		dl_fuse_reply_err(req, EINVAL);
++		DL(fuse_reply_err)(req, EINVAL);
  		return;
  	}
  #endif
@@ -499,33 +499,33 @@
  	
  	if (!(buf = malloc(size)))
 -		fuse_reply_err(req, ENOMEM);
-+		dl_fuse_reply_err(req, ENOMEM);
++		DL(fuse_reply_err)(req, ENOMEM);
  	else if (sqfs_xattr_lookup(&lli.ll->fs, &lli.inode, name, buf, &real))
 -		fuse_reply_err(req, EIO);
-+		dl_fuse_reply_err(req, EIO);
++		DL(fuse_reply_err)(req, EIO);
  	else if (real == 0)
 -		fuse_reply_err(req, sqfs_enoattr());
-+		dl_fuse_reply_err(req, sqfs_enoattr());
++		DL(fuse_reply_err)(req, sqfs_enoattr());
  	else if (size == 0)
 -		fuse_reply_xattr(req, real);
-+		dl_fuse_reply_xattr(req, real);
++		DL(fuse_reply_xattr)(req, real);
  	else if (size < real)
 -		fuse_reply_err(req, ERANGE);
-+		dl_fuse_reply_err(req, ERANGE);
++		DL(fuse_reply_err)(req, ERANGE);
  	else
 -		fuse_reply_buf(req, buf, real);
-+		dl_fuse_reply_buf(req, buf, real);
++		DL(fuse_reply_buf)(req, buf, real);
  	free(buf);
  }
  
  static void sqfs_ll_op_forget(fuse_req_t req, fuse_ino_t ino,
  		unsigned long nlookup) {
-+  LOAD_SYMBOL(void,fuse_reply_none,(fuse_req_t req));
++	LOAD_SYMBOL(void,fuse_reply_none,(fuse_req_t req));
  	sqfs_ll_i lli;
  	sqfs_ll_iget(req, &lli, SQFS_FUSE_INODE_NONE);
  	lli.ll->ino_forget(lli.ll, ino, nlookup);
 -	fuse_reply_none(req);
-+	dl_fuse_reply_none(req);
++	DL(fuse_reply_none)(req);
  }
  
  
@@ -536,15 +536,15 @@
 +	LOAD_SYMBOL(struct fuse_chan *,fuse_mount,(const char *mountpoint, struct fuse_args *args));
  	#ifdef HAVE_NEW_FUSE_UNMOUNT
 -		ch->ch = fuse_mount(mountpoint, args);
-+		ch->ch = dl_fuse_mount(mountpoint, args);
++		ch->ch = DL(fuse_mount)(mountpoint, args);
  	#else
 -		ch->fd = fuse_mount(mountpoint, args);
-+    LOAD_SYMBOL(struct fuse_chan *,fuse_kern_chan_new,(int fd));
-+		ch->fd = dl_fuse_mount(mountpoint, args);
++		LOAD_SYMBOL(struct fuse_chan *,fuse_kern_chan_new,(int fd));
++		ch->fd = DL(fuse_mount)(mountpoint, args);
  		if (ch->fd == -1)
  			return SQFS_ERR;
 -		ch->ch = fuse_kern_chan_new(ch->fd);
-+		ch->ch = dl_fuse_kern_chan_new(ch->fd);
++		ch->ch = DL(fuse_kern_chan_new)(ch->fd);
  	#endif
  	return ch->ch ? SQFS_OK : SQFS_ERR;
  }
@@ -552,13 +552,13 @@
  static void sqfs_ll_unmount(sqfs_ll_chan *ch, const char *mountpoint) {
  	#ifdef HAVE_NEW_FUSE_UNMOUNT
 -		fuse_unmount(mountpoint, ch->ch);
-+    LOAD_SYMBOL(void,fuse_unmount,(const char *mountpoint, struct fuse_chan *ch));
-+		dl_fuse_unmount(mountpoint, ch->ch);
++		LOAD_SYMBOL(void,fuse_unmount,(const char *mountpoint, struct fuse_chan *ch));
++		DL(fuse_unmount)(mountpoint, ch->ch);
  	#else
-+    LOAD_SYMBOL(void,fuse_unmount,(const char *mountpoint));
++		LOAD_SYMBOL(void,fuse_unmount,(const char *mountpoint));
  		close(ch->fd);
 -		fuse_unmount(mountpoint);
-+		dl_fuse_unmount(mountpoint);
++		DL(fuse_unmount)(mountpoint);
  	#endif
  }
  
@@ -566,18 +566,18 @@
  }
  
  int fusefs_main(int argc, char *argv[], void (*mounted) (void)) {
-+  LOAD_SYMBOL(int,fuse_opt_parse,(struct fuse_args *args, void *data, const struct fuse_opt opts[], fuse_opt_proc_t proc));
-+  LOAD_SYMBOL(int,fuse_parse_cmdline,(struct fuse_args *args, char **mountpoint, int *multithreaded, int *foreground));
-+  LOAD_SYMBOL(struct fuse_session *,fuse_lowlevel_new,(struct fuse_args *args, const struct fuse_lowlevel_ops *op, size_t op_size, void *userdata));
-+  LOAD_SYMBOL(int,fuse_set_signal_handlers,(struct fuse_session *se));
-+  LOAD_SYMBOL(void,fuse_session_add_chan,(struct fuse_session *se, struct fuse_chan *ch));
-+  LOAD_SYMBOL(int,fuse_session_loop,(struct fuse_session *se));
-+  LOAD_SYMBOL(void,fuse_remove_signal_handlers,(struct fuse_session *se));
++	LOAD_SYMBOL(int,fuse_opt_parse,(struct fuse_args *args, void *data, const struct fuse_opt opts[], fuse_opt_proc_t proc));
++	LOAD_SYMBOL(int,fuse_parse_cmdline,(struct fuse_args *args, char **mountpoint, int *multithreaded, int *foreground));
++	LOAD_SYMBOL(struct fuse_session *,fuse_lowlevel_new,(struct fuse_args *args, const struct fuse_lowlevel_ops *op, size_t op_size, void *userdata));
++	LOAD_SYMBOL(int,fuse_set_signal_handlers,(struct fuse_session *se));
++	LOAD_SYMBOL(void,fuse_session_add_chan,(struct fuse_session *se, struct fuse_chan *ch));
++	LOAD_SYMBOL(int,fuse_session_loop,(struct fuse_session *se));
++	LOAD_SYMBOL(void,fuse_remove_signal_handlers,(struct fuse_session *se));
 +#if HAVE_DECL_FUSE_SESSION_REMOVE_CHAN
-+  LOAD_SYMBOL(void,fuse_session_remove_chan,(struct fuse_chan *ch));
++	LOAD_SYMBOL(void,fuse_session_remove_chan,(struct fuse_chan *ch));
 +#endif
-+  LOAD_SYMBOL(void,fuse_session_destroy,(struct fuse_session *se));
-+  LOAD_SYMBOL(void,fuse_opt_free_args,(struct fuse_args *args));
++	LOAD_SYMBOL(void,fuse_session_destroy,(struct fuse_session *se));
++	LOAD_SYMBOL(void,fuse_opt_free_args,(struct fuse_args *args));
 +
  	struct fuse_args args;
  	sqfs_opts opts;
@@ -587,11 +587,11 @@
  	opts.mountpoint = 0;
  	opts.offset = 0;
 -	if (fuse_opt_parse(&args, &opts, fuse_opts, sqfs_opt_proc) == -1)
-+	if (dl_fuse_opt_parse(&args, &opts, fuse_opts, sqfs_opt_proc) == -1)
++	if (DL(fuse_opt_parse)(&args, &opts, fuse_opts, sqfs_opt_proc) == -1)
  		sqfs_usage(argv[0], true);
  
 -	if (fuse_parse_cmdline(&args, &mountpoint, &mt, &fg) == -1)
-+	if (dl_fuse_parse_cmdline(&args, &mountpoint, &mt, &fg) == -1)
++	if (DL(fuse_parse_cmdline)(&args, &mountpoint, &mt, &fg) == -1)
  		sqfs_usage(argv[0], true);
  	if (mountpoint == NULL)
  		sqfs_usage(argv[0], true);
@@ -600,41 +600,41 @@
  		err = -1;
  		if (sqfs_ll_mount(&ch, mountpoint, &args) == SQFS_OK) {
 -			struct fuse_session *se = fuse_lowlevel_new(&args,
-+			struct fuse_session *se = dl_fuse_lowlevel_new(&args,
++			struct fuse_session *se = DL(fuse_lowlevel_new)(&args,
  				&sqfs_ll_ops, sizeof(sqfs_ll_ops), ll);	
  			if (se != NULL) {
  				if (sqfs_ll_daemonize(fg) != -1) {
 -					if (fuse_set_signal_handlers(se) != -1) {
 -						fuse_session_add_chan(se, ch.ch);
-+					if (dl_fuse_set_signal_handlers(se) != -1) {
-+						dl_fuse_session_add_chan(se, ch.ch);
++					if (DL(fuse_set_signal_handlers)(se) != -1) {
++						DL(fuse_session_add_chan)(se, ch.ch);
  				if (mounted)
  				  mounted ();
  						/* FIXME: multithreading */
 -						err = fuse_session_loop(se);
 -						fuse_remove_signal_handlers(se);
-+						err = dl_fuse_session_loop(se);
-+						dl_fuse_remove_signal_handlers(se);
++						err = DL(fuse_session_loop)(se);
++						DL(fuse_remove_signal_handlers)(se);
  						#if HAVE_DECL_FUSE_SESSION_REMOVE_CHAN
 -							fuse_session_remove_chan(ch.ch);
-+							dl_fuse_session_remove_chan(ch.ch);
++							DL(fuse_session_remove_chan)(ch.ch);
  						#endif
  					}
  				}
 -				fuse_session_destroy(se);
-+				dl_fuse_session_destroy(se);
++				DL(fuse_session_destroy)(se);
  			}
  			sqfs_ll_destroy(ll);
  			sqfs_ll_unmount(&ch, mountpoint);
  		}
  	}
 -	fuse_opt_free_args(&args);
-+	dl_fuse_opt_free_args(&args);
++	DL(fuse_opt_free_args)(&args);
  	if (mounted)
  	  rmdir (mountpoint);
  	free(ll);
  	free(mountpoint);
-+  CLOSE_LIBRARY;
++	CLOSE_LIBRARY;
  	
  	return -err;
  }


### PR DESCRIPTION
Gets rid of the 'execv error' message.

Also the LOAD_LIBRARY macro is no longer included in the LOAD_SYMBOL macro and building the patched squashfuse library should now be possible without dlopen() support.